### PR TITLE
Add ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@unsplash/sum-types-io-ts",
   "description": "io-ts bindings for @unsplash/sum-types.",
   "version": "0.2.0",
@@ -17,16 +16,21 @@
     "sum-types",
     "io-ts"
   ],
-  "main": "./index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsc -p ./tsconfig.build.json",
+    "build": "rm -rf ./dist/ && mkdir -p ./dist/esm/ ./dist/cjs/ && tsc -p ./tsconfig.build-esm.json && tsc -p ./tsconfig.build-cjs.json && tsc -p ./tsconfig.build-types.json",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ./src/ ./test/ --ext ts",
     "fmt": "prettier .",
     "unit": "jest",
     "docs": "docs-ts",
-    "prepub": "rm -rf dist && mkdir -p dist && cp ./README.md ./dist/ && cat ./package.json | grep -v '\"private\":' > ./dist/package.json && yarn run build"
+    "prepublish": "yarn run build"
   },
   "devDependencies": {
     "@types/eslint": "^7.0.0",

--- a/tsconfig.build-cjs.json
+++ b/tsconfig.build-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs/"
+  },
+  "exclude": ["test/**/*"]
+}

--- a/tsconfig.build-esm.json
+++ b/tsconfig.build-esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./dist/esm/"
+  },
+  "exclude": ["test/**/*"]
+}

--- a/tsconfig.build-types.json
+++ b/tsconfig.build-types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.build-esm.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "./dist/types/",
+    "emitDeclarationOnly": true,
+    "removeComments": false
+  },
+  "exclude": ["test/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "commonjs",
     "lib": ["esnext", "dom"],
+    "moduleResolution": "node",
     "strict": true,
-    "outDir": "./dist/",
-    "declaration": true
+    "declaration": false,
+    "removeComments": true
   },
   "include": ["src/**/*.ts", "test/unit/**/*.ts"]
 }


### PR DESCRIPTION
This PR adds ESM support alongside the preexisting CJS.

Conditional exports, the source of some consumer-side configuration complexity in fp-ts-std, are unneeded as we're only publishing a single index module.

Publishing is now a bit less weird, this does away with publishing in `dist/`. The addition of the `prepublish` script means publishing is now as simple as `yarn/npm publish` without a path or prior command.

My local test repo with Webpack saw the bundle size drop from a total of (not gzipped) 74K to 13K.

Once this is merged I'll publish 0.2.1, update web, and assuming all goes well there replicate the same change to the other sum-types repos.