### PR TITLE
Add nullary mapped codec constructors

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -14,6 +14,7 @@ Added in v0.1.0
 
 - [utils](#utils)
   - [getCodec](#getcodec)
+  - [getCodecFromMappedNullaryTag](#getcodecfrommappednullarytag)
   - [getCodecFromNullaryTag](#getcodecfromnullarytag)
   - [getCodecFromSerialized](#getcodecfromserialized)
   - [getSerializedCodec](#getserializedcodec)
@@ -34,6 +35,53 @@ export declare const getCodec: <A extends Sum.AnyMember>(cs: MemberCodecs<A>, na
 ```
 
 Added in v0.1.0
+
+## getCodecFromMappedNullaryTag
+
+Derive a codec for any given sum `A` in which all the constructors are
+nullary, decoding and encoding to/from the constructor tags via conversion
+functions. Useful for working with stringly APIs.
+
+**Signature**
+
+```ts
+export declare const getCodecFromMappedNullaryTag: <A extends NullaryMember>() => <B>(
+  from: (x: unknown) => O.Option<Tag<A>>,
+  to: (x: Tag<A>) => B
+) => <C>(tags: EveryKeyPresent<Tag<A>, C>, name?: string) => t.Type<A, B, unknown>
+```
+
+**Example**
+
+```ts
+import * as t from 'io-ts'
+import * as Sum from '@unsplash/sum-types'
+import { getCodecFromMappedNullaryTag } from '@unsplash/sum-types-io-ts'
+import * as O from 'fp-ts/Option'
+import * as E from 'fp-ts/Either'
+
+type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain'>
+const Weather = Sum.create<Weather>()
+type Country = 'UK' | 'Italy'
+
+const WeatherFromCountry: t.Type<Weather, Country> = getCodecFromMappedNullaryTag<Weather>()<Country>(
+  (x) => {
+    switch (x) {
+      case 'Italy':
+        return O.some('Sun')
+      case 'UK':
+        return O.some('Rain')
+      default:
+        return O.none
+    }
+  },
+  (x) => (x === 'Sun' ? 'Italy' : 'UK')
+)(['Sun', 'Rain'])
+
+assert.deepStrictEqual(WeatherFromCountry.decode('UK'), E.right(Weather.mk.Rain()))
+```
+
+Added in v0.3.0
 
 ## getCodecFromNullaryTag
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -17,6 +17,7 @@ Added in v0.1.0
   - [getCodecFromMappedNullaryTag](#getcodecfrommappednullarytag)
   - [getCodecFromNullaryTag](#getcodecfromnullarytag)
   - [getCodecFromSerialized](#getcodecfromserialized)
+  - [getCodecFromStringlyMappedNullaryTag](#getcodecfromstringlymappednullarytag)
   - [getSerializedCodec](#getserializedcodec)
 
 ---
@@ -40,7 +41,8 @@ Added in v0.1.0
 
 Derive a codec for any given sum `A` in which all the constructors are
 nullary, decoding and encoding to/from the constructor tags via conversion
-functions. Useful for working with stringly APIs.
+functions. Consider instead `getCodecFromStringlyMappedNullaryTag` for
+stringly APIs.
 
 **Signature**
 
@@ -114,6 +116,46 @@ export declare const getCodecFromSerialized: <A extends Sum.AnyMember>(
 ```
 
 Added in v0.1.0
+
+## getCodecFromStringlyMappedNullaryTag
+
+A convenient alternative to `getCodecFromMappedNullaryTag` for working with
+stringly APIs. The behaviour is unspecified if the input `Record` contains
+duplicate values.
+
+**Signature**
+
+```ts
+export declare const getCodecFromStringlyMappedNullaryTag: <A extends NullaryMember>() => <B extends string>(
+  tos: Record<Tag<A>, B>,
+  name?: string
+) => t.Type<A, B, unknown>
+```
+
+**Example**
+
+```ts
+import * as t from 'io-ts'
+import * as Sum from '@unsplash/sum-types'
+import { getCodecFromStringlyMappedNullaryTag } from '@unsplash/sum-types-io-ts'
+import * as O from 'fp-ts/Option'
+import * as E from 'fp-ts/Either'
+
+type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain'>
+const Weather = Sum.create<Weather>()
+type Country = 'UK' | 'Italy'
+
+const WeatherFromCountry: t.Type<Weather, Country> = getCodecFromStringlyMappedNullaryTag<Weather>()({
+  Sun: 'Italy',
+  Rain: 'UK',
+})
+
+assert.deepStrictEqual(WeatherFromCountry.decode('UK'), E.right(Weather.mk.Rain()))
+```
+
+Added in v0.3.0
+
+-
 
 ## getSerializedCodec
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import * as t from "io-ts"
 import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
 import * as E from "fp-ts/Either"
-import { toArray } from "fp-ts/Record"
+import * as R from "fp-ts/Record"
 import { mapFst } from "fp-ts/Tuple"
 import { Refinement } from "fp-ts/Refinement"
 
@@ -45,7 +45,7 @@ export const getSerializedCodec = <A extends Sum.AnyMember>(
   name = "Serialized Sum",
 ): t.Type<Sum.Serialized<A>> =>
   pipe(
-    toArray(cs) as Array<[Tag<A>, t.Type<Value<A>>]>,
+    R.toArray(cs) as Array<[Tag<A>, t.Type<Value<A>>]>,
     A.map(flow(mapFst(t.literal), xs => t.tuple(xs))),
     ([x, y, ...zs]) => (y === undefined ? x : t.union([x, y, ...zs], name)),
   ) as unknown as t.Type<Sum.Serialized<A>>

--- a/test/type/index.ts
+++ b/test/type/index.ts
@@ -1,8 +1,14 @@
 /* eslint-disable functional/functional-parameters, functional/no-expression-statement, @typescript-eslint/no-unused-vars */
 
 import * as Sum from "@unsplash/sum-types"
-import { getCodecFromSerialized, getCodecFromNullaryTag } from "../../src/index"
+import {
+  getCodecFromSerialized,
+  getCodecFromMappedNullaryTag,
+  getCodecFromNullaryTag,
+} from "../../src/index"
 import * as t from "io-ts"
+import { constant } from "fp-ts/function"
+import * as O from "fp-ts/Option"
 
 type A = Sum.Member<"A1"> | Sum.Member<"A2", number>
 
@@ -13,6 +19,16 @@ getCodecFromSerialized<A>({ A2: t.number }) // $ExpectError
 getCodecFromSerialized<A>({ A1: t.null }) // $ExpectError
 
 type B = Sum.Member<"B1"> | Sum.Member<"B2">
+
+const getCodecFromMappedNullaryTagPA = getCodecFromMappedNullaryTag<B>()(
+  constant(O.none),
+  constant("foo"),
+)
+getCodecFromMappedNullaryTagPA([]) // $ExpectError
+getCodecFromMappedNullaryTagPA(["B1"]) // $ExpectError
+getCodecFromMappedNullaryTagPA(["B2"]) // $ExpectError
+getCodecFromMappedNullaryTagPA(["B1", "B1"]) // $ExpectError
+getCodecFromMappedNullaryTagPA(["B1", "B2"]) // $ExpectType Type<B, string, unknown>
 
 getCodecFromNullaryTag<B>()([]) // $ExpectError
 getCodecFromNullaryTag<B>()(["B1"]) // $ExpectError


### PR DESCRIPTION
Here are the codec constructors we have right now:

- `getCodec`: Pretty much runtime validation only since sum types aren't serialisable. (`sum <-> sum`)
- `getSerialized`: Like `getCodec` but for the serialised forms. (`serialised <-> serialised`)
- `getCodecFromSerialized`: Maps between sum types and their serialised forms. (`sum <-> serialised`)
- `getCodecFromNullaryTag`: Maps between nullary sum types and their tags. (`sum <-> tags`)

These are good but they're still fairly rigid. Specifically if our internal domain doesn't match the foreign data we're decoding, how can we bring it into the fold? (I guess fairly easily with the experimental io-ts modules... one day...) For example:

```ts
type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain'>

type ExternalData = { weather: 'dry' | 'wet' }
```

We'd need to decode with something like `t.union` and map the string literals to our sum type after decoding has finished. This PR solves this by adding two new codec constructors:

- `getCodecFromMappedNullaryTag`: Maps between nullary sum types and any arbitrary data using conversion functions. (`sum <-> any`)
- `getCodecFromStringlyMappedNullaryTag`: Maps between nullary sum types and some other strings. This is more ergonomic than `getCodecFromMappedNullaryTag` for a more common use case. (`sum <-> strings`)

Examples are provided in the code (and compiled into the documentation). The above example can now be solved with:

```ts
const ExternalData = t.type({
  weather: getCodecFromStringlyMappedNullaryTag<Weather>()({ Sun: 'dry', Rain: 'wet' }),
})
```

Why nullary sums specifically? io-ts currently requires runtime validation separate from decoding. This is easy for nullary sums for which we simply require an input of all its keys (directly or via the object you see in the example). Non-nullary sums are more difficult and require a codec for their associated values. We could build out another function for that use case, but it's terribly verbose and I'd like to put it off until there's actually a need for it.