### PR TITLE
Widen stringly mapped constructor to all primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to semantic versioning.
 
+## 0.5.0 (_Unreleased_)
+
+Replace `getCodecFromStringlyMappedNullaryTag` with the more flexible `getCodecFromPrimitiveMappedNullaryTag`.
+
 ## 0.4.0 (2022-09-05)
 
 Support `@unsplash/sum-types` ^0.3.0.

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -16,8 +16,8 @@ Added in v0.1.0
   - [getCodec](#getcodec)
   - [getCodecFromMappedNullaryTag](#getcodecfrommappednullarytag)
   - [getCodecFromNullaryTag](#getcodecfromnullarytag)
+  - [getCodecFromPrimitiveMappedNullaryTag](#getcodecfromprimitivemappednullarytag)
   - [getCodecFromSerialized](#getcodecfromserialized)
-  - [getCodecFromStringlyMappedNullaryTag](#getcodecfromstringlymappednullarytag)
   - [getSerializedCodec](#getserializedcodec)
 
 ---
@@ -44,7 +44,7 @@ Added in v0.1.0
 
 Derive a codec for any given sum `A` in which all the constructors are
 nullary, decoding and encoding to/from the constructor tags via conversion
-functions. Consider instead `getCodecFromStringlyMappedNullaryTag` for
+functions. Consider instead `getCodecFromPrimitiveMappedNullaryTag` for
 stringly APIs.
 
 **Signature**
@@ -104,6 +104,48 @@ export declare const getCodecFromNullaryTag: <A extends NullaryMember>() => <B>(
 
 Added in v0.3.0
 
+## getCodecFromPrimitiveMappedNullaryTag
+
+A convenient alternative to `getCodecFromMappedNullaryTag` for working with
+for example stringly APIs. The behaviour is unspecified if the input `Record`
+contains duplicate values.
+
+**Signature**
+
+```ts
+export declare const getCodecFromPrimitiveMappedNullaryTag: <A extends NullaryMember>() => <
+  B extends string | number | bigint | boolean | null | undefined
+>(
+  tos: Record<Tag<A>, B>,
+  name?: string
+) => t.Type<A, B, unknown>
+```
+
+**Example**
+
+```ts
+import * as t from 'io-ts'
+import * as Sum from '@unsplash/sum-types'
+import { getCodecFromPrimitiveMappedNullaryTag } from '@unsplash/sum-types-io-ts'
+import * as O from 'fp-ts/Option'
+import * as E from 'fp-ts/Either'
+
+type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain'>
+const Weather = Sum.create<Weather>()
+type Country = 'UK' | 'Italy'
+
+const WeatherFromCountry: t.Type<Weather, Country> = getCodecFromPrimitiveMappedNullaryTag<Weather>()({
+  Sun: 'Italy',
+  Rain: 'UK',
+})
+
+assert.deepStrictEqual(WeatherFromCountry.decode('UK'), E.right(Weather.mk.Rain()))
+```
+
+Added in v0.5.0
+
+-
+
 ## getCodecFromSerialized
 
 Derive a codec for any given sum `A` provided codecs for all its members'
@@ -119,46 +161,6 @@ export declare const getCodecFromSerialized: <A extends Sum.AnyMember>() => <B e
 ```
 
 Added in v0.1.0
-
-## getCodecFromStringlyMappedNullaryTag
-
-A convenient alternative to `getCodecFromMappedNullaryTag` for working with
-stringly APIs. The behaviour is unspecified if the input `Record` contains
-duplicate values.
-
-**Signature**
-
-```ts
-export declare const getCodecFromStringlyMappedNullaryTag: <A extends NullaryMember>() => <B extends string>(
-  tos: Record<Tag<A>, B>,
-  name?: string
-) => t.Type<A, B, unknown>
-```
-
-**Example**
-
-```ts
-import * as t from 'io-ts'
-import * as Sum from '@unsplash/sum-types'
-import { getCodecFromStringlyMappedNullaryTag } from '@unsplash/sum-types-io-ts'
-import * as O from 'fp-ts/Option'
-import * as E from 'fp-ts/Either'
-
-type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain'>
-const Weather = Sum.create<Weather>()
-type Country = 'UK' | 'Italy'
-
-const WeatherFromCountry: t.Type<Weather, Country> = getCodecFromStringlyMappedNullaryTag<Weather>()({
-  Sun: 'Italy',
-  Rain: 'UK',
-})
-
-assert.deepStrictEqual(WeatherFromCountry.decode('UK'), E.right(Weather.mk.Rain()))
-```
-
-Added in v0.3.0
-
--
 
 ## getSerializedCodec
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,12 @@ import * as t from "io-ts"
 import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
 import * as E from "fp-ts/Either"
+import * as Map from "fp-ts/Map"
 import * as R from "fp-ts/Record"
 import * as Str from "fp-ts/string"
 import { mapFst } from "fp-ts/Tuple"
 import { Refinement } from "fp-ts/Refinement"
+import { eqStrict } from "fp-ts/Eq"
 
 // We must add the `any` type argument or it won't distribute over unions for
 // some reason.
@@ -215,15 +217,15 @@ export const getCodecFromStringlyMappedNullaryTag =
     tos: Record<Tag<A>, B>,
     name = "Sum Stringly Mapped Tag",
   ): t.Type<A, B> => {
-    const froms = pipe(
+    const froms: Map<B, Tag<A>> = pipe(
       tos,
-      R.reduceWithIndex(Str.Ord)({} as Record<B, Tag<A>>, (k, xs, v) =>
-        R.upsertAt(v, k)(xs),
+      R.reduceWithIndex(Str.Ord)(new globalThis.Map<B, Tag<A>>(), (k, xs, v) =>
+        Map.upsertAt<B>(eqStrict)(v, k)(xs),
       ),
     )
 
     return getCodecFromMappedNullaryTag<A>()(
-      x => (typeof x === "string" ? R.lookup(x)(froms) : O.none),
+      x => Map.lookup(eqStrict)(x)(froms),
       x => tos[x],
     )(Object.keys(tos) as Array<Tag<A>>, name)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ type Value<A> = A extends Sum.Member<any, infer B> ? B : never
 
 type NullaryMember = Sum.Member<string>
 
+type Primitive = string | number | boolean | bigint | undefined | null
+
 /**
  * An object from member tags to codecs of their values.
  *
@@ -125,7 +127,7 @@ type EveryKeyPresent<A, B> = Array<A> extends B
 /**
  * Derive a codec for any given sum `A` in which all the constructors are
  * nullary, decoding and encoding to/from the constructor tags via conversion
- * functions. Consider instead `getCodecFromStringlyMappedNullaryTag` for
+ * functions. Consider instead `getCodecFromPrimitiveMappedNullaryTag` for
  * stringly APIs.
  *
  * @example
@@ -190,13 +192,13 @@ export const getCodecFromMappedNullaryTag =
 
 /**
  * A convenient alternative to `getCodecFromMappedNullaryTag` for working with
- * stringly APIs. The behaviour is unspecified if the input `Record` contains
- * duplicate values.
+ * for example stringly APIs. The behaviour is unspecified if the input `Record`
+ * contains duplicate values.
  *
  * @example
  * import * as t from "io-ts"
  * import * as Sum from "@unsplash/sum-types"
- * import { getCodecFromStringlyMappedNullaryTag } from "@unsplash/sum-types-io-ts"
+ * import { getCodecFromPrimitiveMappedNullaryTag } from "@unsplash/sum-types-io-ts"
  * import * as O from "fp-ts/Option"
  * import * as E from "fp-ts/Either"
  *
@@ -205,17 +207,17 @@ export const getCodecFromMappedNullaryTag =
  * type Country = "UK" | "Italy"
  *
  * const WeatherFromCountry: t.Type<Weather, Country> =
- *   getCodecFromStringlyMappedNullaryTag<Weather>()({ Sun: "Italy", Rain: "UK" })
+ *   getCodecFromPrimitiveMappedNullaryTag<Weather>()({ Sun: "Italy", Rain: "UK" })
  *
  * assert.deepStrictEqual(WeatherFromCountry.decode("UK"), E.right(Weather.mk.Rain()))
  *
- * @since 0.3.0
+ * @since 0.5.0
  **/
-export const getCodecFromStringlyMappedNullaryTag =
+export const getCodecFromPrimitiveMappedNullaryTag =
   <A extends NullaryMember>() =>
-  <B extends string>(
+  <B extends Primitive>(
     tos: Record<Tag<A>, B>,
-    name = "Sum Stringly Mapped Tag",
+    name = "Sum Primitive Mapped Tag",
   ): t.Type<A, B> => {
     const froms: Map<B, Tag<A>> = pipe(
       tos,
@@ -239,7 +241,7 @@ export const getCodecFromStringlyMappedNullaryTag =
 export const getCodecFromNullaryTag =
   <A extends NullaryMember>() =>
   <B>(tags: EveryKeyPresent<Tag<A>, B>, name = "Sum Tag"): t.Type<A, string> =>
-    getCodecFromStringlyMappedNullaryTag<A>()(
+    getCodecFromPrimitiveMappedNullaryTag<A>()(
       pipe(
         tags,
         A.reduce({} as Record<Tag<A>, string>, (xs, y) =>


### PR DESCRIPTION
Solves this internal use case: https://github.com/unsplash/unsplash-web/pull/9143#discussion_r1042133211

Currently the stringly mapped codec constructor - one of the most convenient - only supports matching against strings. This PR widens it to support any primitive type. This is as wide as we can go without requiring `Eq`s from the consumer.