### PR TITLE
`MappedType` added

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,9 +14,10 @@ module.exports = {
   },
   rules: {
     "functional/prefer-type-literal": 0,
+    "functional/no-class": 0,
     "functional/no-expression-statement": [
       2,
-      { ignorePattern: "(describe)|(it)|(expect)|(fc.)" },
+      { ignorePattern: "(describe)|(it)|(expect)|(fc.)|(super)" },
     ],
     "@typescript-eslint/array-type": [1, { default: "generic" }],
     "@typescript-eslint/strict-boolean-expressions": [

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -13,6 +13,8 @@ Added in v0.1.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [utils](#utils)
+  - [MappedType (class)](#mappedtype-class)
+    - [\_tag (property)](#_tag-property)
   - [getCodec](#getcodec)
   - [getCodecFromMappedNullaryTag](#getcodecfrommappednullarytag)
   - [getCodecFromNullaryTag](#getcodecfromnullarytag)
@@ -23,6 +25,34 @@ Added in v0.1.0
 ---
 
 # utils
+
+## MappedType (class)
+
+**Signature**
+
+```ts
+export declare class MappedType<A, B> {
+  constructor(
+    name: string,
+    is: MappedType<A, B>['is'],
+    validate: MappedType<A, B>['validate'],
+    encode: MappedType<A, B>['encode'],
+    readonly Map: Record<Tag<A>, B>
+  )
+}
+```
+
+Added in v0.5.1
+
+### \_tag (property)
+
+**Signature**
+
+```ts
+readonly _tag: "@unsplash/sum-types-io-ts/MappedType"
+```
+
+Added in v0.5.1
 
 ## getCodec
 
@@ -118,7 +148,7 @@ export declare const getCodecFromPrimitiveMappedNullaryTag: <A extends NullaryMe
 >(
   tos: Record<Tag<A>, B>,
   name?: string
-) => t.Type<A, B, unknown>
+) => MappedType<A, B>
 ```
 
 **Example**

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,13 +194,17 @@ export const getCodecFromMappedNullaryTag =
  * @since 0.5.1
  */
 export class MappedType<A, B> extends t.Type<A, B, unknown> {
-  readonly _tag: "@unsplash/sum-types-io-ts/MappedType" = "@unsplash/sum-types-io-ts/MappedType"
+  /**
+   * @since 0.5.1
+   */
+  readonly _tag: "@unsplash/sum-types-io-ts/MappedType" =
+    "@unsplash/sum-types-io-ts/MappedType"
   constructor(
     name: string,
     is: MappedType<A, B>["is"],
     validate: MappedType<A, B>["validate"],
     encode: MappedType<A, B>["encode"],
-    readonly Map: Record<Tag<A>, B>
+    readonly Map: Record<Tag<A>, B>,
   ) {
     super(name, is, validate, encode)
   }
@@ -247,7 +251,13 @@ export const getCodecFromPrimitiveMappedNullaryTag =
       x => tos[x],
     )(Object.keys(tos) as Array<Tag<A>>, name)
 
-    return new MappedType(codec.name, codec.is, codec.validate, codec.encode, tos)
+    return new MappedType(
+      codec.name,
+      codec.is,
+      codec.validate,
+      codec.encode,
+      tos,
+    )
   }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,9 @@ export const getCodecFromMappedNullaryTag =
     )
   }
 
+/**
+ * @since 0.5.1
+ */
 export class MappedType<A, B> extends t.Type<A, B, unknown> {
   readonly _tag: "@unsplash/sum-types-io-ts/MappedType" = "@unsplash/sum-types-io-ts/MappedType"
   constructor(

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,19 @@ export const getCodecFromMappedNullaryTag =
     )
   }
 
+export class MappedType<A, B> extends t.Type<A, B, unknown> {
+  readonly _tag: "@unsplash/sum-types-io-ts/MappedType" = "@unsplash/sum-types-io-ts/MappedType"
+  constructor(
+    name: string,
+    is: MappedType<A, B>["is"],
+    validate: MappedType<A, B>["validate"],
+    encode: MappedType<A, B>["encode"],
+    readonly Map: Record<Tag<A>, B>
+  ) {
+    super(name, is, validate, encode)
+  }
+}
+
 /**
  * A convenient alternative to `getCodecFromMappedNullaryTag` for working with
  * for example stringly APIs. The behaviour is unspecified if the input `Record`
@@ -218,7 +231,7 @@ export const getCodecFromPrimitiveMappedNullaryTag =
   <B extends Primitive>(
     tos: Record<Tag<A>, B>,
     name = "Sum Primitive Mapped Tag",
-  ): t.Type<A, B> => {
+  ): MappedType<A, B> => {
     const froms: Map<B, Tag<A>> = pipe(
       tos,
       R.reduceWithIndex(Str.Ord)(new globalThis.Map<B, Tag<A>>(), (k, xs, v) =>
@@ -226,10 +239,12 @@ export const getCodecFromPrimitiveMappedNullaryTag =
       ),
     )
 
-    return getCodecFromMappedNullaryTag<A>()(
+    const codec = getCodecFromMappedNullaryTag<A>()(
       x => Map.lookup(eqStrict)(x)(froms),
       x => tos[x],
     )(Object.keys(tos) as Array<Tag<A>>, name)
+
+    return new MappedType(codec.name, codec.is, codec.validate, codec.encode, tos)
   }
 
 /**

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -281,6 +281,10 @@ describe("index", () => {
       NB: 2,
     })
 
+    it("Map", () => {
+      expect(c.Map).toEqual({ NA: "1", NB: 2 })
+    })
+
     it("type guards", () => {
       expect(c.is(NA())).toBe(true)
       expect(c.is("NA")).toBe(false)


### PR DESCRIPTION
Add  `MappedType` to allow access to the mapping of `getCodecFromPrimitiveMappedNullaryTag` after the codec was created.