### PR TITLE
getCodecFromMappedNullaryTag#is handles unsafe inputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,12 @@ type OutputsOf<
     Sum.Member<Tag<A>, B[Tag<A>] extends t.Type<any, infer C> ? C : never>
   : never
 
-const unknownSerialize = (x: unknown): readonly [unknown, unknown] =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Sum.serialize(x as any)
+const unknownSerialize = (
+  x: unknown,
+): O.Option<readonly [unknown, unknown]> => {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
+  return O.tryCatch(() => Sum.serialize(x as any))
+}
 
 /**
  * Derive a codec for `Serialized<A>` for any given sum `A` provided codecs for

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -272,6 +272,10 @@ describe("index", () => {
 
     it("`is` returns false when getting non sum-types inputs", () => {
       expect(c.is(undefined)).toBe(false)
+      expect(c.is({})).toBe(false)
+      expect(c.is([])).toBe(false)
+      expect(c.is(Symbol("test"))).toBe(false)
+      expect(c.is(null)).toBe(false)
     })
   })
 

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -269,6 +269,10 @@ describe("index", () => {
         E.right(["NA", null]),
       )
     })
+
+    it("`is` doesn't throw when getting unsafe inputs", () => {
+      expect(c.is(undefined)).toBe(false)
+    })
   })
 
   describe("getCodecFromPrimitiveMappedNullaryTag", () => {

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -270,7 +270,7 @@ describe("index", () => {
       )
     })
 
-    it("`is` doesn't throw when getting unsafe inputs", () => {
+    it("`is` returns false when getting non sum-types inputs", () => {
       expect(c.is(undefined)).toBe(false)
     })
   })


### PR DESCRIPTION
Here's my proposed solution to fix the bug highlighted by the test here: https://github.com/unsplash/sum-types-io-ts/pull/15/commits/cc300f3b88c65b005a0109b09ca4b12500c70ec5

Alternatively, we could have a predicate available in `sum-types` to be able to deal with `unknown` inputs and we could leverage that here.

Unsplash internal ref: https://crewlabs.slack.com/archives/C0STWEZ2B/p1684158203122269