### PR TITLE
Various object codecs

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -25,8 +25,8 @@ Added in v0.1.0
   - [getInternallyTaggedCodec](#getinternallytaggedcodec)
   - [getSerializedCodec](#getserializedcodec)
   - [getUntaggedCodec](#getuntaggedcodec)
-  - [nullary](#nullary)
   - [nullaryFrom](#nullaryfrom)
+  - [nullaryFromEmpty](#nullaryfromempty)
 
 ---
 
@@ -86,14 +86,14 @@ export declare const getAdjacentlyTaggedCodec: <K extends string>(
 ```ts
 import * as t from 'io-ts'
 import * as Sum from '@unsplash/sum-types'
-import { nullary, getAdjacentlyTaggedCodec } from '@unsplash/sum-types-io-ts'
+import { nullaryFromEmpty, getAdjacentlyTaggedCodec } from '@unsplash/sum-types-io-ts'
 import * as E from 'fp-ts/Either'
 
 type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', number>
 const Weather = Sum.create<Weather>()
 
 const WeatherCodec = getAdjacentlyTaggedCodec('tag')('value')(Weather)({
-  Sun: nullary,
+  Sun: nullaryFromEmpty,
   Rain: t.number,
 })
 
@@ -223,8 +223,6 @@ assert.deepStrictEqual(WeatherFromCountry.decode('UK'), E.right(Weather.mk.Rain)
 
 Added in v0.5.0
 
--
-
 ## getCodecFromSerialized
 
 Derive a codec for any given sum `A` provided codecs for all its members'
@@ -260,14 +258,14 @@ export declare const getExternallyTaggedCodec: <A extends Sum.AnyMember>(
 ```ts
 import * as t from 'io-ts'
 import * as Sum from '@unsplash/sum-types'
-import { nullary, getExternallyTaggedCodec } from '@unsplash/sum-types-io-ts'
+import { nullaryFromEmpty, getExternallyTaggedCodec } from '@unsplash/sum-types-io-ts'
 import * as E from 'fp-ts/Either'
 
 type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', number>
 const Weather = Sum.create<Weather>()
 
 const WeatherCodec = getExternallyTaggedCodec(Weather)({
-  Sun: nullary,
+  Sun: nullaryFromEmpty,
   Rain: t.number,
 })
 
@@ -305,14 +303,14 @@ export declare const getInternallyTaggedCodec: <K extends string>(
 ```ts
 import * as t from 'io-ts'
 import * as Sum from '@unsplash/sum-types'
-import { nullary, getInternallyTaggedCodec } from '@unsplash/sum-types-io-ts'
+import { nullaryFromEmpty, getInternallyTaggedCodec } from '@unsplash/sum-types-io-ts'
 import * as E from 'fp-ts/Either'
 
 type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', { mm: number }>
 const Weather = Sum.create<Weather>()
 
 const WeatherCodec = getInternallyTaggedCodec('tag')(Weather)({
-  Sun: nullary,
+  Sun: nullaryFromEmpty,
   Rain: t.strict({ mm: t.number }),
 })
 
@@ -359,7 +357,7 @@ export declare const getUntaggedCodec: <A extends Sum.AnyMember>(
 ```ts
 import * as t from 'io-ts'
 import * as Sum from '@unsplash/sum-types'
-import { nullary, getUntaggedCodec } from '@unsplash/sum-types-io-ts'
+import { nullaryFromEmpty, getUntaggedCodec } from '@unsplash/sum-types-io-ts'
 import * as E from 'fp-ts/Either'
 
 type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', { mm: number }>
@@ -368,7 +366,7 @@ const Weather = Sum.create<Weather>()
 const WeatherFromRainfall = getUntaggedCodec(Weather)({
   Rain: t.strict({ mm: t.number }),
   // This codec will match any object so it needs to come last.
-  Sun: nullary,
+  Sun: nullaryFromEmpty,
 })
 
 assert.deepStrictEqual(WeatherFromRainfall.decode({ mm: 123, foo: 'bar' }), E.right(Weather.mk.Rain({ mm: 123 })))
@@ -378,25 +376,11 @@ assert.deepStrictEqual(WeatherFromRainfall.decode({ foo: 'bar' }), E.right(Weath
 
 Added in v0.7.0
 
-## nullary
-
-A representation of nullary member values that encodes to `undefined` for
-better JSON interop, and decodes from `undefined`, `null`, or empty objects
-(i.e. any object).
-
-**Signature**
-
-```ts
-export declare const nullary: t.Type<null, Record<string, unknown> | null | undefined, unknown>
-```
-
-Added in v0.7.0
-
 ## nullaryFrom
 
 Derive a codec for nullary members to/from any other type. If the encoded
-representation is `null` or forming part of an object then `nullary` can be
-used instead.
+representation forms part of an object then `nullaryFromEmpty` can be used
+instead. Incompatible with `Serialized` if not encoding to `null`.
 
 **Signature**
 
@@ -411,8 +395,22 @@ import * as t from 'io-ts'
 import { nullaryFrom } from '@unsplash/sum-types-io-ts'
 
 // This will decode any object to null and encode to an empty object. Instead
-// consider `nullary`.
+// consider `nullaryFromEmpty`.
 nullaryFrom({})(t.type({}))
+```
+
+Added in v0.7.0
+
+## nullaryFromEmpty
+
+A representation of nullary member values that encodes to `undefined` for
+better JSON interop, and decodes from `undefined`, `null`, or empty objects
+(i.e. any object). Incompatible with `Serialized`.
+
+**Signature**
+
+```ts
+export declare const nullaryFromEmpty: t.Type<null, Record<string, unknown> | null | undefined, unknown>
 ```
 
 Added in v0.7.0

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -157,7 +157,6 @@ export declare const getCodecFromPrimitiveMappedNullaryTag: <A extends NullaryMe
 import * as t from 'io-ts'
 import * as Sum from '@unsplash/sum-types'
 import { getCodecFromPrimitiveMappedNullaryTag } from '@unsplash/sum-types-io-ts'
-import * as O from 'fp-ts/Option'
 import * as E from 'fp-ts/Either'
 
 type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain'>

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -15,6 +15,7 @@ Added in v0.1.0
 - [utils](#utils)
   - [MappedType (class)](#mappedtype-class)
     - [\_tag (property)](#_tag-property)
+  - [getAdjacentlyTaggedCodec](#getadjacentlytaggedcodec)
   - [getCodec](#getcodec)
   - [getCodecFromMappedNullaryTag](#getcodecfrommappednullarytag)
   - [getCodecFromNullaryTag](#getcodecfromnullarytag)
@@ -57,6 +58,50 @@ readonly _tag: "@unsplash/sum-types-io-ts/MappedType"
 ```
 
 Added in v0.5.1
+
+## getAdjacentlyTaggedCodec
+
+Derive a codec for any given sum `A` provided codecs for all its members'
+values, decoding and encoding to an object with sibling member tags and
+values.
+
+Due to the distinct, isolated member tag, it's not possible for overlaps to
+occur.
+
+**Signature**
+
+```ts
+export declare const getAdjacentlyTaggedCodec: <K extends string>(
+  tagKey: K
+) => <V extends string>(
+  valueKey: V
+) => <A extends Sum.AnyMember>(
+  sum: Sum.Sum<A>
+) => <C extends MemberCodecs<A>>(cs: C, name?: string) => t.Type<A, AdjacentlyTagged<K, V, A, C>, unknown>
+```
+
+**Example**
+
+```ts
+import * as t from 'io-ts'
+import * as Sum from '@unsplash/sum-types'
+import { nullary, getAdjacentlyTaggedCodec } from '@unsplash/sum-types-io-ts'
+import * as E from 'fp-ts/Either'
+
+type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', number>
+const Weather = Sum.create<Weather>()
+
+const WeatherCodec = getAdjacentlyTaggedCodec('tag')('value')(Weather)({
+  Sun: nullary,
+  Rain: t.number,
+})
+
+assert.deepStrictEqual(WeatherCodec.decode({ tag: 'Sun', value: null }), E.right(Weather.mk.Sun))
+
+assert.deepStrictEqual(WeatherCodec.decode({ tag: 'Rain', value: 123 }), E.right(Weather.mk.Rain(123)))
+```
+
+Added in v0.7.0
 
 ## getCodec
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -22,6 +22,7 @@ Added in v0.1.0
   - [getCodecFromPrimitiveMappedNullaryTag](#getcodecfromprimitivemappednullarytag)
   - [getCodecFromSerialized](#getcodecfromserialized)
   - [getExternallyTaggedCodec](#getexternallytaggedcodec)
+  - [getInternallyTaggedCodec](#getinternallytaggedcodec)
   - [getSerializedCodec](#getserializedcodec)
   - [getUntaggedCodec](#getuntaggedcodec)
   - [nullary](#nullary)
@@ -273,6 +274,51 @@ const WeatherCodec = getExternallyTaggedCodec(Weather)({
 assert.deepStrictEqual(WeatherCodec.decode({ Sun: undefined }), E.right(Weather.mk.Sun))
 
 assert.deepStrictEqual(WeatherCodec.decode({ Rain: 123 }), E.right(Weather.mk.Rain(123)))
+```
+
+Added in v0.7.0
+
+## getInternallyTaggedCodec
+
+Derive a codec for any given sum `A` provided codecs for all its members'
+values, decoding and encoding to an object with sibling member tags and
+values.
+
+Due to the distinct, isolated member tag, it's not possible for overlaps to
+occur.
+
+**Signature**
+
+```ts
+export declare const getInternallyTaggedCodec: <K extends string>(
+  tagKey: K
+) => <A extends Sum.AnyMember>(
+  sum: Sum.Sum<A>
+) => <C extends MemberCodecs<A, Record<string, unknown> | null | undefined>>(
+  cs: C,
+  name?: string
+) => t.Type<A, InternallyTagged<K, A, C>, unknown>
+```
+
+**Example**
+
+```ts
+import * as t from 'io-ts'
+import * as Sum from '@unsplash/sum-types'
+import { nullary, getInternallyTaggedCodec } from '@unsplash/sum-types-io-ts'
+import * as E from 'fp-ts/Either'
+
+type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', { mm: number }>
+const Weather = Sum.create<Weather>()
+
+const WeatherCodec = getInternallyTaggedCodec('tag')(Weather)({
+  Sun: nullary,
+  Rain: t.strict({ mm: t.number }),
+})
+
+assert.deepStrictEqual(WeatherCodec.decode({ tag: 'Sun' }), E.right(Weather.mk.Sun))
+
+assert.deepStrictEqual(WeatherCodec.decode({ tag: 'Rain', mm: 123 }), E.right(Weather.mk.Rain({ mm: 123 })))
 ```
 
 Added in v0.7.0

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -21,6 +21,7 @@ Added in v0.1.0
   - [getCodecFromPrimitiveMappedNullaryTag](#getcodecfromprimitivemappednullarytag)
   - [getCodecFromSerialized](#getcodecfromserialized)
   - [getSerializedCodec](#getserializedcodec)
+  - [nullary](#nullary)
 
 ---
 
@@ -205,3 +206,15 @@ export declare const getSerializedCodec: <A extends Sum.AnyMember>() => <B exten
 ```
 
 Added in v0.1.0
+
+## nullary
+
+An alias for `t.null` for consistency alongside `nullaryFrom`.
+
+**Signature**
+
+```ts
+export declare const nullary: t.Type<null, null, unknown>
+```
+
+Added in v0.7.0

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -22,6 +22,7 @@ Added in v0.1.0
   - [getCodecFromSerialized](#getcodecfromserialized)
   - [getSerializedCodec](#getserializedcodec)
   - [nullary](#nullary)
+  - [nullaryFrom](#nullaryfrom)
 
 ---
 
@@ -215,6 +216,33 @@ An alias for `t.null` for consistency alongside `nullaryFrom`.
 
 ```ts
 export declare const nullary: t.Type<null, null, unknown>
+```
+
+Added in v0.7.0
+
+## nullaryFrom
+
+Derive a codec for nullary members to/from any other type. Necessary for many
+object-based use cases. If the encoded representation is `null` then
+`nullary` can be directly used instead.
+
+**Signature**
+
+```ts
+export declare const nullaryFrom: <A>(to: A) => (from: t.Type<A, unknown, unknown>) => t.Type<null, A, unknown>
+```
+
+**Example**
+
+```ts
+import * as t from 'io-ts'
+import { nullaryFrom } from '@unsplash/sum-types-io-ts'
+
+// This will decode any object to null and encode to an empty object.
+nullaryFrom({})(t.type({}))
+
+// Equivalent to `nullary`.
+nullaryFrom(null)(t.null)
 ```
 
 Added in v0.7.0

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -359,7 +359,7 @@ export declare const getUntaggedCodec: <A extends Sum.AnyMember>(
 ```ts
 import * as t from 'io-ts'
 import * as Sum from '@unsplash/sum-types'
-import { nullaryFrom, getUntaggedCodec } from '@unsplash/sum-types-io-ts'
+import { nullary, getUntaggedCodec } from '@unsplash/sum-types-io-ts'
 import * as E from 'fp-ts/Either'
 
 type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', { mm: number }>
@@ -368,7 +368,7 @@ const Weather = Sum.create<Weather>()
 const WeatherFromRainfall = getUntaggedCodec(Weather)({
   Rain: t.strict({ mm: t.number }),
   // This codec will match any object so it needs to come last.
-  Sun: nullaryFrom({})(t.strict({})),
+  Sun: nullary,
 })
 
 assert.deepStrictEqual(WeatherFromRainfall.decode({ mm: 123, foo: 'bar' }), E.right(Weather.mk.Rain({ mm: 123 })))
@@ -394,9 +394,9 @@ Added in v0.7.0
 
 ## nullaryFrom
 
-Derive a codec for nullary members to/from any other type. Necessary for many
-object-based use cases. If the encoded representation is `null` then
-`nullary` can be directly used instead.
+Derive a codec for nullary members to/from any other type. If the encoded
+representation is `null` or forming part of an object then `nullary` can be
+used instead.
 
 **Signature**
 
@@ -410,11 +410,9 @@ export declare const nullaryFrom: <A>(to: A) => (from: t.Type<A, unknown, unknow
 import * as t from 'io-ts'
 import { nullaryFrom } from '@unsplash/sum-types-io-ts'
 
-// This will decode any object to null and encode to an empty object.
+// This will decode any object to null and encode to an empty object. Instead
+// consider `nullary`.
 nullaryFrom({})(t.type({}))
-
-// Equivalent to `nullary`.
-nullaryFrom(null)(t.null)
 ```
 
 Added in v0.7.0

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -21,6 +21,7 @@ Added in v0.1.0
   - [getCodecFromPrimitiveMappedNullaryTag](#getcodecfromprimitivemappednullarytag)
   - [getCodecFromSerialized](#getcodecfromserialized)
   - [getSerializedCodec](#getserializedcodec)
+  - [getUntaggedCodec](#getuntaggedcodec)
   - [nullary](#nullary)
   - [nullaryFrom](#nullaryfrom)
 
@@ -207,6 +208,45 @@ export declare const getSerializedCodec: <A extends Sum.AnyMember>() => <B exten
 ```
 
 Added in v0.1.0
+
+## getUntaggedCodec
+
+Derive a codec for any given sum `A` provided codecs for all its members'
+values, decoding and encoding directly to/from the member codecs.
+
+Should the types overlap, the first valid codec will succeed.
+
+**Signature**
+
+```ts
+export declare const getUntaggedCodec: <A extends Sum.AnyMember>(
+  sum: Sum.Sum<A>
+) => <C extends MemberCodecs<A>>(cs: C, name?: string) => t.Type<A, Untagged<A, C>, unknown>
+```
+
+**Example**
+
+```ts
+import * as t from 'io-ts'
+import * as Sum from '@unsplash/sum-types'
+import { nullaryFrom, getUntaggedCodec } from '@unsplash/sum-types-io-ts'
+import * as E from 'fp-ts/Either'
+
+type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', { mm: number }>
+const Weather = Sum.create<Weather>()
+
+const WeatherFromRainfall = getUntaggedCodec(Weather)({
+  Rain: t.strict({ mm: t.number }),
+  // This codec will match any object so it needs to come last.
+  Sun: nullaryFrom({})(t.strict({})),
+})
+
+assert.deepStrictEqual(WeatherFromRainfall.decode({ mm: 123, foo: 'bar' }), E.right(Weather.mk.Rain({ mm: 123 })))
+
+assert.deepStrictEqual(WeatherFromRainfall.decode({ foo: 'bar' }), E.right(Weather.mk.Sun))
+```
+
+Added in v0.7.0
 
 ## nullary
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -96,7 +96,7 @@ const WeatherCodec = getAdjacentlyTaggedCodec('tag')('value')(Weather)({
   Rain: t.number,
 })
 
-assert.deepStrictEqual(WeatherCodec.decode({ tag: 'Sun', value: null }), E.right(Weather.mk.Sun))
+assert.deepStrictEqual(WeatherCodec.decode({ tag: 'Sun' }), E.right(Weather.mk.Sun))
 
 assert.deepStrictEqual(WeatherCodec.decode({ tag: 'Rain', value: 123 }), E.right(Weather.mk.Rain(123)))
 ```
@@ -270,7 +270,7 @@ const WeatherCodec = getExternallyTaggedCodec(Weather)({
   Rain: t.number,
 })
 
-assert.deepStrictEqual(WeatherCodec.decode({ Sun: null }), E.right(Weather.mk.Sun))
+assert.deepStrictEqual(WeatherCodec.decode({ Sun: undefined }), E.right(Weather.mk.Sun))
 
 assert.deepStrictEqual(WeatherCodec.decode({ Rain: 123 }), E.right(Weather.mk.Rain(123)))
 ```
@@ -334,12 +334,13 @@ Added in v0.7.0
 
 ## nullary
 
-An alias for `t.null` for consistency alongside `nullaryFrom`.
+A representation of nullary member values that encodes to `undefined` for
+better JSON interop.
 
 **Signature**
 
 ```ts
-export declare const nullary: t.Type<null, null, unknown>
+export declare const nullary: t.Type<null, undefined, unknown>
 ```
 
 Added in v0.7.0

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -20,6 +20,7 @@ Added in v0.1.0
   - [getCodecFromNullaryTag](#getcodecfromnullarytag)
   - [getCodecFromPrimitiveMappedNullaryTag](#getcodecfromprimitivemappednullarytag)
   - [getCodecFromSerialized](#getcodecfromserialized)
+  - [getExternallyTaggedCodec](#getexternallytaggedcodec)
   - [getSerializedCodec](#getserializedcodec)
   - [getUntaggedCodec](#getuntaggedcodec)
   - [nullary](#nullary)
@@ -192,6 +193,44 @@ export declare const getCodecFromSerialized: <A extends Sum.AnyMember>(
 ```
 
 Added in v0.1.0
+
+## getExternallyTaggedCodec
+
+Derive a codec for any given sum `A` provided codecs for all its members'
+values, decoding and encoding to an object tagged by the sum member tag.
+
+Should the types overlap, the first valid codec will succeed.
+
+**Signature**
+
+```ts
+export declare const getExternallyTaggedCodec: <A extends Sum.AnyMember>(
+  sum: Sum.Sum<A>
+) => <C extends MemberCodecs<A>>(cs: C, name?: string) => t.Type<A, ExternallyTagged<A, C>, unknown>
+```
+
+**Example**
+
+```ts
+import * as t from 'io-ts'
+import * as Sum from '@unsplash/sum-types'
+import { nullary, getExternallyTaggedCodec } from '@unsplash/sum-types-io-ts'
+import * as E from 'fp-ts/Either'
+
+type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', number>
+const Weather = Sum.create<Weather>()
+
+const WeatherCodec = getExternallyTaggedCodec(Weather)({
+  Sun: nullary,
+  Rain: t.number,
+})
+
+assert.deepStrictEqual(WeatherCodec.decode({ Sun: null }), E.right(Weather.mk.Sun))
+
+assert.deepStrictEqual(WeatherCodec.decode({ Rain: 123 }), E.right(Weather.mk.Rain(123)))
+```
+
+Added in v0.7.0
 
 ## getSerializedCodec
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -77,7 +77,7 @@ export declare const getAdjacentlyTaggedCodec: <K extends string>(
   valueKey: V
 ) => <A extends Sum.AnyMember>(
   sum: Sum.Sum<A>
-) => <C extends MemberCodecs<A>>(cs: C, name?: string) => t.Type<A, AdjacentlyTagged<K, V, A, C>, unknown>
+) => <C extends MemberCodecs<A, unknown>>(cs: C, name?: string) => t.Type<A, AdjacentlyTagged<K, V, A, C>, unknown>
 ```
 
 **Example**
@@ -113,7 +113,7 @@ values.
 ```ts
 export declare const getCodec: <A extends Sum.AnyMember>(
   sum: Sum.Sum<A>
-) => <B extends MemberCodecs<A>>(cs: B, name?: string) => t.Type<A, OutputsOf<A, B>, unknown>
+) => <B extends MemberCodecs<A, unknown>>(cs: B, name?: string) => t.Type<A, OutputsOf<A, B>, unknown>
 ```
 
 Added in v0.1.0
@@ -234,7 +234,7 @@ values, decoding and encoding to/from `Serialized<A>`.
 ```ts
 export declare const getCodecFromSerialized: <A extends Sum.AnyMember>(
   sum: Sum.Sum<A>
-) => <B extends MemberCodecs<A>>(cs: B, name?: string) => t.Type<A, Sum.Serialized<OutputsOf<A, B>>, unknown>
+) => <B extends MemberCodecs<A, unknown>>(cs: B, name?: string) => t.Type<A, Sum.Serialized<OutputsOf<A, B>>, unknown>
 ```
 
 Added in v0.1.0
@@ -251,7 +251,7 @@ Should the types overlap, the first valid codec will succeed.
 ```ts
 export declare const getExternallyTaggedCodec: <A extends Sum.AnyMember>(
   sum: Sum.Sum<A>
-) => <C extends MemberCodecs<A>>(cs: C, name?: string) => t.Type<A, ExternallyTagged<A, C>, unknown>
+) => <C extends MemberCodecs<A, unknown>>(cs: C, name?: string) => t.Type<A, ExternallyTagged<A, C>, unknown>
 ```
 
 **Example**
@@ -285,7 +285,7 @@ all its members` values.
 **Signature**
 
 ```ts
-export declare const getSerializedCodec: <A extends Sum.AnyMember>() => <B extends MemberCodecs<A>>(
+export declare const getSerializedCodec: <A extends Sum.AnyMember>() => <B extends MemberCodecs<A, unknown>>(
   cs: B,
   name?: string
 ) => t.Type<Sum.Serialized<A>, Sum.Serialized<OutputsOf<A, B>>, unknown>
@@ -305,7 +305,7 @@ Should the types overlap, the first valid codec will succeed.
 ```ts
 export declare const getUntaggedCodec: <A extends Sum.AnyMember>(
   sum: Sum.Sum<A>
-) => <C extends MemberCodecs<A>>(cs: C, name?: string) => t.Type<A, Untagged<A, C>, unknown>
+) => <C extends MemberCodecs<A, unknown>>(cs: C, name?: string) => t.Type<A, Untagged<A, C>, unknown>
 ```
 
 **Example**

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -335,12 +335,13 @@ Added in v0.7.0
 ## nullary
 
 A representation of nullary member values that encodes to `undefined` for
-better JSON interop.
+better JSON interop, and decodes from `undefined`, `null`, or empty objects
+(i.e. any object).
 
 **Signature**
 
 ```ts
-export declare const nullary: t.Type<null, undefined, unknown>
+export declare const nullary: t.Type<null, Record<string, unknown> | null | undefined, unknown>
 ```
 
 Added in v0.7.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,13 +128,15 @@ export const nullaryFrom =
 
 /**
  * A representation of nullary member values that encodes to `undefined` for
- * better JSON interop.
+ * better JSON interop, and decodes from `undefined`, `null`, or empty objects
+ * (i.e. any object).
  *
  * @since 0.7.0
  */
-export const nullary: t.Type<null, undefined> = nullaryFrom(undefined)(
-  t.undefined,
-)
+export const nullary: t.Type<null, undefined | null | Record<string, unknown>> =
+  nullaryFrom<undefined | null | Record<string, unknown>>(undefined)(
+    t.union([t.undefined, t.null, t.type({})]),
+  )
 
 /**
  * Derive a codec for `Serialized<A>` for any given sum `A` provided codecs for

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,19 +100,17 @@ const union1 = <A extends [t.Mixed, ...Array<t.Mixed>]>(
     : t.union(xs as unknown as [t.Mixed, t.Mixed, ...Array<t.Mixed>], name)
 
 /**
- * Derive a codec for nullary members to/from any other type. Necessary for many
- * object-based use cases. If the encoded representation is `null` then
- * `nullary` can be directly used instead.
+ * Derive a codec for nullary members to/from any other type. If the encoded
+ * representation is `null` or forming part of an object then `nullary` can be
+ * used instead.
  *
  * @example
  * import * as t from "io-ts"
  * import { nullaryFrom } from "@unsplash/sum-types-io-ts"
  *
- * // This will decode any object to null and encode to an empty object.
+ * // This will decode any object to null and encode to an empty object. Instead
+ * // consider `nullary`.
  * nullaryFrom({})(t.type({}))
- *
- * // Equivalent to `nullary`.
- * nullaryFrom(null)(t.null)
  *
  * @since 0.7.0
  */
@@ -620,7 +618,7 @@ const getUntaggedMemberCodec =
  * @example
  * import * as t from "io-ts"
  * import * as Sum from "@unsplash/sum-types"
- * import { nullaryFrom, getUntaggedCodec } from "@unsplash/sum-types-io-ts"
+ * import { nullary, getUntaggedCodec } from "@unsplash/sum-types-io-ts"
  * import * as E from "fp-ts/Either"
  *
  * type Weather = Sum.Member<"Sun"> | Sum.Member<"Rain", { mm: number }>
@@ -629,7 +627,7 @@ const getUntaggedMemberCodec =
  * const WeatherFromRainfall = getUntaggedCodec(Weather)({
  *   Rain: t.strict({ mm: t.number }),
  *   // This codec will match any object so it needs to come last.
- *   Sun: nullaryFrom({})(t.strict({})),
+ *   Sun: nullary,
  * })
  *
  * assert.deepStrictEqual(

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,6 @@ export class MappedType<A, B> extends t.Type<A, B, unknown> {
  * import * as t from "io-ts"
  * import * as Sum from "@unsplash/sum-types"
  * import { getCodecFromPrimitiveMappedNullaryTag } from "@unsplash/sum-types-io-ts"
- * import * as O from "fp-ts/Option"
  * import * as E from "fp-ts/Either"
  *
  * type Weather = Sum.Member<"Sun"> | Sum.Member<"Rain">

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,12 +46,13 @@ type EveryKeyPresent<A, B> = Array<A> extends B
 /**
  * An object from member tags to codecs of their values.
  *
- * We require codecs for members without values as well as we need all the keys
- * to be present at runtime, and taking `t.null` is more consistent and less
- * magical than any alternative.
+ * We require codecs for members without values as well as needing all of the
+ * keys to be present at runtime.
+ *
+ * `B` exists to support constraints on encoded representations.
  */
-type MemberCodecs<A extends Sum.AnyMember> = {
-  readonly [B in A as Tag<B>]: t.Type<Value<B>, unknown>
+type MemberCodecs<A extends Sum.AnyMember, B = unknown> = {
+  readonly [C in A as Tag<C>]: t.Type<Value<C>, B>
 }
 
 type OutputsOf<

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
 /* eslint-disable functional/functional-parameters, functional/prefer-readonly-type, @typescript-eslint/unbound-method */
 
 import * as Sum from "@unsplash/sum-types"
-import { flow, pipe } from "fp-ts/function"
+import { constant, flow, pipe } from "fp-ts/function"
 import * as t from "io-ts"
 import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
@@ -100,6 +100,33 @@ const union1 = <A extends [t.Mixed, ...Array<t.Mixed>]>(
  * @since 0.7.0
  */
 export const nullary: t.Type<null> = t.null
+
+/**
+ * Derive a codec for nullary members to/from any other type. Necessary for many
+ * object-based use cases. If the encoded representation is `null` then
+ * `nullary` can be directly used instead.
+ *
+ * @example
+ * import * as t from "io-ts"
+ * import { nullaryFrom } from "@unsplash/sum-types-io-ts"
+ *
+ * // This will decode any object to null and encode to an empty object.
+ * nullaryFrom({})(t.type({}))
+ *
+ * // Equivalent to `nullary`.
+ * nullaryFrom(null)(t.null)
+ *
+ * @since 0.7.0
+ */
+export const nullaryFrom =
+  <A>(to: A) =>
+  (from: t.Type<A, unknown>): t.Type<null, A, unknown> =>
+    new t.Type(
+      "foo",
+      nullary.is,
+      (i, c) => pipe(from.validate(i, c), E.map(constant(null))),
+      constant(to),
+    )
 
 /**
  * Derive a codec for `Serialized<A>` for any given sum `A` provided codecs for

--- a/src/index.ts
+++ b/src/index.ts
@@ -455,6 +455,119 @@ export const getExternallyTaggedCodec =
  * Supports any encoded representation of nullary member values.
  *
  * @example
+ * AdjacentlyTagged<"k", "v", Weather, ...> = { k: Sun; v: null } | { k: Rain; v: { mm: number } }
+ */
+type AdjacentlyTagged<
+  K extends string,
+  V extends string,
+  A extends Sum.AnyMember,
+  B extends MemberCodecs<A>,
+> = A extends Sum.AnyMember
+  ? {
+      [_ in K]: Tag<A>
+    } & {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [_ in V]: B[Tag<A>] extends t.Type<any, infer C> ? C : never
+    }
+  : never
+
+const getAdjacentlyTaggedMemberCodec =
+  <K extends string>(tagKey: K) =>
+  <V extends string>(valueKey: V) =>
+  <A extends Sum.AnyMember>(sum: Sum.Sum<A>) =>
+  <B extends Tag<A>>(tag: B) =>
+  <C>(
+    vc: t.Type<ValueByTag<A, B>, C>,
+    name = "Sum",
+  ): t.Type<A, Record<K, B> & Record<V, C>> =>
+    new t.Type(
+      name,
+      (x): x is A =>
+        pipe(
+          unknownSerialize(x),
+          O.exists(y => y[0] === tag && vc.is(y[1])),
+        ),
+      (i, ctx) =>
+        pipe(
+          t
+            .strict({ [tagKey]: t.literal(tag), [valueKey]: vc })
+            .validate(i, ctx),
+          E.map(x =>
+            Sum.deserialize(sum)([
+              tag,
+              x[valueKey],
+            ] as unknown as Sum.Serialized<A>),
+          ),
+        ),
+      flow(
+        Sum.serialize,
+        ([k, v]) =>
+          ({
+            [tagKey]: k,
+            [valueKey]: vc.encode(v as ValueByTag<A, B>),
+          } as Record<K, B> & Record<V, C>),
+      ),
+    )
+
+/**
+ * Derive a codec for any given sum `A` provided codecs for all its members'
+ * values, decoding and encoding to an object with sibling member tags and
+ * values.
+ *
+ * Due to the distinct, isolated member tag, it's not possible for overlaps to
+ * occur.
+ *
+ * @example
+ * import * as t from "io-ts"
+ * import * as Sum from "@unsplash/sum-types"
+ * import { nullary, getAdjacentlyTaggedCodec } from "@unsplash/sum-types-io-ts"
+ * import * as E from "fp-ts/Either"
+ *
+ * type Weather = Sum.Member<"Sun"> | Sum.Member<"Rain", number>
+ * const Weather = Sum.create<Weather>()
+ *
+ * const WeatherCodec = getAdjacentlyTaggedCodec("tag")("value")(Weather)({
+ *   Sun: nullary,
+ *   Rain: t.number,
+ * })
+ *
+ * assert.deepStrictEqual(
+ *   WeatherCodec.decode({ tag: "Sun", value: null }),
+ *   E.right(Weather.mk.Sun),
+ * )
+ *
+ * assert.deepStrictEqual(
+ *   WeatherCodec.decode({ tag: "Rain", value: 123 }),
+ *   E.right(Weather.mk.Rain(123)),
+ * )
+ *
+ * @since 0.7.0
+ */
+export const getAdjacentlyTaggedCodec =
+  <K extends string>(tagKey: K) =>
+  <V extends string>(valueKey: V) =>
+  <A extends Sum.AnyMember>(sum: Sum.Sum<A>) =>
+  <C extends MemberCodecs<A>>(
+    cs: C,
+    name = "Sum",
+  ): t.Type<A, AdjacentlyTagged<K, V, A, C>> =>
+    pipe(
+      cs,
+      // NB `R.toArray` doesn't preserve object order.
+      Object.entries,
+      A.map(([tag, codec]) =>
+        getAdjacentlyTaggedMemberCodec(tagKey)(valueKey)(sum)(tag as Tag<A>)(
+          codec as t.Type<Value<A>>,
+          name,
+        ),
+      ),
+      ([x, ...ys]) => union1([x, ...ys]),
+    ) as unknown as t.Type<A, AdjacentlyTagged<K, V, A, C>>
+
+/**
+ * Supports any encoded representation of nullary member values.
+ *
+ * @example
  * Untagged<Weather, ...> = {} | { mm: number }
  */
 type Untagged<

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,12 +71,10 @@ const unknownSerialize = (
 }
 
 /**
- * Excess property checking at function boundaries should protect us against
- * excess keys, however without an assertion, encapsulated here, `Object.keys`
- * will still err on the side of caution and widen `Array<Tag<A>>` to
- * `Array<string>`.
+ * Without an assertion, encapsulated here, `Object.keys` will err on the side
+ * of caution and widen `Array<Tag<A>>` to `Array<string>`.
  */
-const getTags: <A extends Sum.AnyMember>(
+const unsafeGetTags: <A extends Sum.AnyMember>(
   x: Record<Tag<A>, unknown>,
 ) => Array<Tag<A>> = Object.keys
 
@@ -355,7 +353,7 @@ export const getCodecFromPrimitiveMappedNullaryTag =
     const codec = getCodecFromMappedNullaryTag(sum)(
       x => Map.lookup(eqStrict)(x)(froms),
       x => tos[x],
-    )(getTags(tos), name)
+    )(unsafeGetTags(tos), name)
 
     return new MappedType(
       codec.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,16 @@ const unknownSerialize = (
 }
 
 /**
+ * Excess property checking at function boundaries should protect us against
+ * excess keys, however without an assertion, encapsulated here, `Object.keys`
+ * will still err on the side of caution and widen `Array<Tag<A>>` to
+ * `Array<string>`.
+ */
+const getTags: <A extends Sum.AnyMember>(
+  x: Record<Tag<A>, unknown>,
+) => Array<Tag<A>> = Object.keys
+
+/**
  * Derive a codec for `Serialized<A>` for any given sum `A` provided codecs for
  * all its members` values.
  *
@@ -266,7 +276,7 @@ export const getCodecFromPrimitiveMappedNullaryTag =
     const codec = getCodecFromMappedNullaryTag(sum)(
       x => Map.lookup(eqStrict)(x)(froms),
       x => tos[x],
-    )(Object.keys(tos) as Array<Tag<A>>, name)
+    )(getTags(tos), name)
 
     return new MappedType(
       codec.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export const nullaryFrom =
   <A>(to: A) =>
   (from: t.Type<A, unknown>): t.Type<null, A, unknown> =>
     new t.Type(
-      "foo",
+      `nullaryFrom(${from.name})`,
       t.null.is,
       (i, c) => pipe(from.validate(i, c), E.map(constant(null))),
       constant(to),

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,7 +336,7 @@ export class MappedType<A, B> extends t.Type<A, B, unknown> {
  * assert.deepStrictEqual(WeatherFromCountry.decode("UK"), E.right(Weather.mk.Rain))
  *
  * @since 0.5.0
- **/
+ */
 export const getCodecFromPrimitiveMappedNullaryTag =
   <A extends NullaryMember>(sum: Sum.Sum<A>) =>
   <B extends Primitive>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -561,8 +561,7 @@ export const getAdjacentlyTaggedCodec =
   ): t.Type<A, AdjacentlyTagged<K, V, A, C>> =>
     pipe(
       cs,
-      // NB `R.toArray` doesn't preserve object order.
-      Object.entries,
+      R.toArray,
       A.map(([tag, codec]) =>
         getAdjacentlyTaggedMemberCodec(tagKey)(valueKey)(sum)(tag as Tag<A>)(
           codec as t.Type<Value<A>>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,13 @@ const union1 = <A extends [t.Mixed, ...Array<t.Mixed>]>(
     : t.union(xs as unknown as [t.Mixed, t.Mixed, ...Array<t.Mixed>], name)
 
 /**
+ * An alias for `t.null` for consistency alongside `nullaryFrom`.
+ *
+ * @since 0.7.0
+ */
+export const nullary: t.Type<null> = t.null
+
+/**
  * Derive a codec for `Serialized<A>` for any given sum `A` provided codecs for
  * all its members` values.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,7 +377,7 @@ type ExternallyTagged<
   B extends MemberCodecs<A>,
 > = A extends Sum.AnyMember
   ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    { [_ in Tag<A>]: B[Tag<A>] extends t.Type<any, infer C> ? C : never }
+    Record<Tag<A>, B[Tag<A>] extends t.Type<any, infer C> ? C : never>
   : never
 
 const getExternallyTaggedMemberCodec =
@@ -472,12 +472,9 @@ type AdjacentlyTagged<
   A extends Sum.AnyMember,
   B extends MemberCodecs<A>,
 > = A extends Sum.AnyMember
-  ? {
-      [_ in K]: Tag<A>
-    } & {
+  ? Record<K, Tag<A>> &
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      [_ in V]: B[Tag<A>] extends t.Type<any, infer C> ? C : never
-    }
+      Record<V, B[Tag<A>] extends t.Type<any, infer C> ? C : never>
   : never
 
 const getAdjacentlyTaggedMemberCodec =
@@ -670,10 +667,8 @@ type InternallyTagged<
   A extends Sum.AnyMember,
   B extends MemberCodecs<A>,
 > = A extends Sum.AnyMember
-  ? {
-      [_ in K]: Tag<A>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } & (B[Tag<A>] extends t.Type<any, infer C> ? C : never)
+  ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Record<K, Tag<A>> & (B[Tag<A>] extends t.Type<any, infer C> ? C : never)
   : never
 
 const getInternallyTaggedMemberCodec =

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,17 @@ type NullaryMember = Sum.Member<string>
 type Primitive = string | number | boolean | bigint | undefined | null
 
 /**
+ * Ensures that every key in union `A` is present at least once in array `B`.
+ *
+ * @link https://github.com/Microsoft/TypeScript/issues/13298#issuecomment-468733257
+ */
+type EveryKeyPresent<A, B> = Array<A> extends B
+  ? B extends Array<A>
+    ? B
+    : never
+  : never
+
+/**
  * An object from member tags to codecs of their values.
  *
  * We require codecs for members without values as well as we need all the keys
@@ -126,17 +137,6 @@ export const getCodec =
       ),
     )
   }
-
-/**
- * Ensures that every key in union `A` is present at least once in array `B`.
- *
- * @link https://github.com/Microsoft/TypeScript/issues/13298#issuecomment-468733257
- */
-type EveryKeyPresent<A, B> = Array<A> extends B
-  ? B extends Array<A>
-    ? B
-    : never
-  : never
 
 /**
  * Derive a codec for any given sum `A` in which all the constructors are

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,15 +122,15 @@ const foldToUnion =
 
 /**
  * Derive a codec for nullary members to/from any other type. If the encoded
- * representation is `null` or forming part of an object then `nullary` can be
- * used instead.
+ * representation forms part of an object then `nullaryFromEmpty` can be used
+ * instead. Incompatible with `Serialized` if not encoding to `null`.
  *
  * @example
  * import * as t from "io-ts"
  * import { nullaryFrom } from "@unsplash/sum-types-io-ts"
  *
  * // This will decode any object to null and encode to an empty object. Instead
- * // consider `nullary`.
+ * // consider `nullaryFromEmpty`.
  * nullaryFrom({})(t.type({}))
  *
  * @since 0.7.0
@@ -148,14 +148,16 @@ export const nullaryFrom =
 /**
  * A representation of nullary member values that encodes to `undefined` for
  * better JSON interop, and decodes from `undefined`, `null`, or empty objects
- * (i.e. any object).
+ * (i.e. any object). Incompatible with `Serialized`.
  *
  * @since 0.7.0
  */
-export const nullary: t.Type<null, undefined | null | Record<string, unknown>> =
-  nullaryFrom<undefined | null | Record<string, unknown>>(undefined)(
-    t.union([t.undefined, t.null, t.type({})]),
-  )
+export const nullaryFromEmpty: t.Type<
+  null,
+  undefined | null | Record<string, unknown>
+> = nullaryFrom<undefined | null | Record<string, unknown>>(undefined)(
+  t.union([t.undefined, t.null, t.type({})]),
+)
 
 /**
  * Derive a codec for `Serialized<A>` for any given sum `A` provided codecs for
@@ -435,14 +437,14 @@ const getExternallyTaggedMemberCodec =
  * @example
  * import * as t from "io-ts"
  * import * as Sum from "@unsplash/sum-types"
- * import { nullary, getExternallyTaggedCodec } from "@unsplash/sum-types-io-ts"
+ * import { nullaryFromEmpty, getExternallyTaggedCodec } from "@unsplash/sum-types-io-ts"
  * import * as E from "fp-ts/Either"
  *
  * type Weather = Sum.Member<"Sun"> | Sum.Member<"Rain", number>
  * const Weather = Sum.create<Weather>()
  *
  * const WeatherCodec = getExternallyTaggedCodec(Weather)({
- *   Sun: nullary,
+ *   Sun: nullaryFromEmpty,
  *   Rain: t.number,
  * })
  *
@@ -534,14 +536,14 @@ const getAdjacentlyTaggedMemberCodec =
  * @example
  * import * as t from "io-ts"
  * import * as Sum from "@unsplash/sum-types"
- * import { nullary, getAdjacentlyTaggedCodec } from "@unsplash/sum-types-io-ts"
+ * import { nullaryFromEmpty, getAdjacentlyTaggedCodec } from "@unsplash/sum-types-io-ts"
  * import * as E from "fp-ts/Either"
  *
  * type Weather = Sum.Member<"Sun"> | Sum.Member<"Rain", number>
  * const Weather = Sum.create<Weather>()
  *
  * const WeatherCodec = getAdjacentlyTaggedCodec("tag")("value")(Weather)({
- *   Sun: nullary,
+ *   Sun: nullaryFromEmpty,
  *   Rain: t.number,
  * })
  *
@@ -615,7 +617,7 @@ const getUntaggedMemberCodec =
  * @example
  * import * as t from "io-ts"
  * import * as Sum from "@unsplash/sum-types"
- * import { nullary, getUntaggedCodec } from "@unsplash/sum-types-io-ts"
+ * import { nullaryFromEmpty, getUntaggedCodec } from "@unsplash/sum-types-io-ts"
  * import * as E from "fp-ts/Either"
  *
  * type Weather = Sum.Member<"Sun"> | Sum.Member<"Rain", { mm: number }>
@@ -624,7 +626,7 @@ const getUntaggedMemberCodec =
  * const WeatherFromRainfall = getUntaggedCodec(Weather)({
  *   Rain: t.strict({ mm: t.number }),
  *   // This codec will match any object so it needs to come last.
- *   Sun: nullary,
+ *   Sun: nullaryFromEmpty,
  * })
  *
  * assert.deepStrictEqual(
@@ -707,14 +709,14 @@ const getInternallyTaggedMemberCodec =
  * @example
  * import * as t from "io-ts"
  * import * as Sum from "@unsplash/sum-types"
- * import { nullary, getInternallyTaggedCodec } from "@unsplash/sum-types-io-ts"
+ * import { nullaryFromEmpty, getInternallyTaggedCodec } from "@unsplash/sum-types-io-ts"
  * import * as E from "fp-ts/Either"
  *
  * type Weather = Sum.Member<"Sun"> | Sum.Member<"Rain", { mm: number }>
  * const Weather = Sum.create<Weather>()
  *
  * const WeatherCodec = getInternallyTaggedCodec("tag")(Weather)({
- *   Sun: nullary,
+ *   Sun: nullaryFromEmpty,
  *   Rain: t.strict({ mm: t.number }),
  * })
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -396,7 +396,7 @@ const getExternallyTaggedMemberCodec =
           // that manually.
           typeof i === "object" && i !== null && k in i
             ? E.right(i)
-            : t.failure(i, ctx, `Missing key ${k}`),
+            : t.failure(i, ctx, `Missing key "${k}"`),
           E.chain(x => t.strict({ [k]: vc }).validate(x, ctx)),
           E.map(x =>
             Sum.deserialize(sum)([k, x[k]] as unknown as Sum.Serialized<A>),

--- a/test/type/index.ts
+++ b/test/type/index.ts
@@ -5,10 +5,16 @@ import {
   getCodecFromSerialized,
   getCodecFromMappedNullaryTag,
   getCodecFromNullaryTag,
+  getUntaggedCodec,
+  getInternallyTaggedCodec,
+  getExternallyTaggedCodec,
+  getAdjacentlyTaggedCodec,
+  nullary,
 } from "../../src/index"
 import * as t from "io-ts"
 import { constant } from "fp-ts/function"
 import * as O from "fp-ts/Option"
+import { NumberFromString } from "io-ts-types"
 
 type A = Sum.Member<"A1"> | Sum.Member<"A2", number>
 const A = Sum.create<A>()
@@ -37,3 +43,25 @@ getCodecFromNullaryTag(B)(["B1"]) // $ExpectError
 getCodecFromNullaryTag(B)(["B2"]) // $ExpectError
 getCodecFromNullaryTag(B)(["B1", "B1"]) // $ExpectError
 getCodecFromNullaryTag(B)(["B1", "B2"]) // $ExpectType Type<B, string, unknown>
+
+type C = Sum.Member<"C1"> | Sum.Member<"C2", { readonly k: number }>
+const C = Sum.create<C>()
+
+const c1 = nullary
+const c2 = t.strict({ k: NumberFromString })
+
+getUntaggedCodec(C)({ C2: c2, C1: c1 }) // $ExpectType Type<C, Record<string, unknown> | { k: string; } | null | undefined, unknown>
+getUntaggedCodec(C)({ C1: c1 }) // $ExpectError
+getUntaggedCodec(C)({ C2: c2 }) // $ExpectError
+
+getInternallyTaggedCodec("tag")(C)({ C2: c2, C1: c1 }) // $ExpectType Type<C, (Record<"tag", "C1"> & Record<string, unknown>) | (Record<"tag", "C2"> & { k: string; }), unknown>
+getInternallyTaggedCodec("tag")(C)({ C1: c1 }) // $ExpectError
+getInternallyTaggedCodec("tag")(C)({ C2: c2 }) // $ExpectError
+
+getExternallyTaggedCodec(C)({ C2: c2, C1: c1 }) // $ExpectType Type<C, Record<"C1", Record<string, unknown> | null | undefined> | Record<"C2", { k: string; }>, unknown>
+getExternallyTaggedCodec(C)({ C1: c1 }) // $ExpectError
+getExternallyTaggedCodec(C)({ C2: c2 }) // $ExpectError
+
+getAdjacentlyTaggedCodec("tag")("val")(C)({ C2: c2, C1: c1 }) // $ExpectType Type<C, (Record<"tag", "C1"> & Record<"val", Record<string, unknown> | null | undefined>) | (Record<"tag", "C2"> & Record<"val", { k: string; }>), unknown>
+getAdjacentlyTaggedCodec("tag")("val")(C)({ C1: c1 }) // $ExpectError
+getAdjacentlyTaggedCodec("tag")("val")(C)({ C2: c2 }) // $ExpectError

--- a/test/type/index.ts
+++ b/test/type/index.ts
@@ -9,7 +9,7 @@ import {
   getInternallyTaggedCodec,
   getExternallyTaggedCodec,
   getAdjacentlyTaggedCodec,
-  nullary,
+  nullaryFromEmpty,
 } from "../../src/index"
 import * as t from "io-ts"
 import { constant } from "fp-ts/function"
@@ -47,7 +47,7 @@ getCodecFromNullaryTag(B)(["B1", "B2"]) // $ExpectType Type<B, string, unknown>
 type C = Sum.Member<"C1"> | Sum.Member<"C2", { readonly k: number }>
 const C = Sum.create<C>()
 
-const c1 = nullary
+const c1 = nullaryFromEmpty
 const c2 = t.strict({ k: NumberFromString })
 
 getUntaggedCodec(C)({ C2: c2, C1: c1 }) // $ExpectType Type<C, Record<string, unknown> | { k: string; } | null | undefined, unknown>

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -516,6 +516,14 @@ describe("index", () => {
       )
     })
 
+    it("requires key to be present even if nullary", () => {
+      type T = Sum.Member<"A">
+      const T = Sum.create<T>()
+      const c = getExternallyTaggedCodec(T)({ A: nullary })
+
+      expect(E.isLeft(c.decode({}))).toBe(true)
+    })
+
     it("tests codecs in input order", () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const f = flow(getExternallyTaggedCodec(T), x => x.decode)
@@ -596,12 +604,12 @@ describe("index", () => {
       const T = Sum.create<T>()
       const c = getAdjacentlyTaggedCodec("tag")("value")(T)
 
-      const cn = c({ A: nullary })
+      const cn = c({ A: t.null })
       expect(cn.decode({ tag: "A", value: null })).toEqual(E.right(T.mk.A))
       expect(cn.decode({ tag: "A" })).not.toEqual(E.right(T.mk.A))
       expect(cn.encode(T.mk.A)).toEqual({ tag: "A", value: null })
 
-      const cu = c({ A: nullaryFrom(undefined)(t.undefined) })
+      const cu = c({ A: nullary })
       expect(
         cu.decode({
           tag: "A",
@@ -618,7 +626,7 @@ describe("index", () => {
       const MaybeNum = Sum.create<Maybe<number>>()
       const c = getAdjacentlyTaggedCodec("_tag")("value")(MaybeNum)({
         Some: t.number,
-        None: nullaryFrom(undefined)(t.undefined),
+        None: nullary,
       })
 
       expect(c.decode(O.some(123))).toEqual(E.right(MaybeNum.mk.Some(123)))

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -9,6 +9,8 @@ import {
   getCodecFromMappedNullaryTag,
   getCodecFromPrimitiveMappedNullaryTag,
   getCodecFromNullaryTag,
+  getUntaggedCodec,
+  nullaryFrom,
 } from "../../src/index"
 import * as t from "io-ts"
 import { flow, pipe } from "fp-ts/function"
@@ -358,6 +360,98 @@ describe("index", () => {
     it("decodes known tag", () => {
       expect(pipe(c.decode("NA"), E.map(Sum.serialize))).toEqual(
         E.right(["NA", null]),
+      )
+    })
+  })
+
+  describe("getUntaggedCodec", () => {
+    type T = Sum.Member<"A"> | Sum.Member<"B", number>
+    const T = Sum.create<T>()
+    const {
+      mk: { A, B },
+    } = T
+
+    // Typically nullary members would be represented by null or an empty
+    // object, but we support anything for which a codec can be provided, so
+    // let's test that.
+    const c = getUntaggedCodec(T)({
+      A: nullaryFrom(false as const)(t.literal(false)),
+      B: NumberFromString,
+    })
+
+    it("type guards", () => {
+      expect(c.is(A)).toBe(true)
+      expect(c.is(B(123))).toBe(true)
+
+      expect(c.is("A")).toBe(false)
+      expect(c.is("B")).toBe(false)
+      expect(c.is({})).toBe(false)
+      expect(c.is(false)).toBe(false)
+      expect(c.is(123)).toBe(false)
+      expect(c.is("123")).toBe(false)
+      expect(c.is({ k: 123 })).toBe(false)
+      expect(c.is({ k: "123" })).toBe(false)
+    })
+
+    it("encodes", () => {
+      expect(c.encode(A)).toBe(false)
+      expect(c.encode(B(123))).toEqual("123")
+    })
+
+    it("does not decode bad inputs", () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const f = flow(c.decode, E.isLeft)
+
+      expect(f("A")).toBe(true)
+      expect(f("B")).toBe(true)
+      expect(f(A)).toBe(true)
+      expect(f(B(123))).toBe(true)
+      expect(f({})).toBe(true)
+      expect(f(true)).toBe(true)
+      expect(f(123)).toBe(true)
+      expect(f({ x: "123" })).toBe(true)
+    })
+
+    it("decodes good inputs", () => {
+      expect(c.decode(false)).toEqual(E.right(A))
+
+      fc.assert(
+        fc.property(fc.integer({ min: 0 }), n =>
+          expect(c.decode(String(n))).toEqual(E.right(B(n))),
+        ),
+      )
+    })
+
+    it("tests codecs in input order", () => {
+      type T =
+        | Sum.Member<"N1">
+        | Sum.Member<"N2">
+        | Sum.Member<"U1", number>
+        | Sum.Member<"U2", number>
+      const T = Sum.create<T>()
+
+      const nc = nullaryFrom(false as const)(t.literal(false))
+      const ncs = {
+        N1: nc,
+        N2: nc,
+      }
+
+      const uc = NumberFromString
+      const ucs = {
+        U1: uc,
+        U2: uc,
+      }
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const f = flow(getUntaggedCodec(T), x => x.decode)
+
+      expect(f({ N1: nc, N2: nc, ...ucs })(false)).toEqual(E.right(T.mk.N1))
+      expect(f({ N2: nc, N1: nc, ...ucs })(false)).toEqual(E.right(T.mk.N2))
+      expect(f({ U1: uc, U2: uc, ...ncs })("123")).toEqual(
+        E.right(T.mk.U1(123)),
+      )
+      expect(f({ U2: uc, U1: uc, ...ncs })("123")).toEqual(
+        E.right(T.mk.U2(123)),
       )
     })
   })

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -563,7 +563,7 @@ describe("index", () => {
       expect(c.is(false)).toBe(false)
       expect(c.is(123)).toBe(false)
       expect(c.is("123")).toBe(false)
-      expect(c.is({ tag: B, value: "123" })).toBe(false)
+      expect(c.is({ tag: "B", value: "123" })).toBe(false)
     })
 
     it("encodes", () => {

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -608,7 +608,10 @@ describe("index", () => {
       const cx = c({ A: nullary })
       expect(cx.decode({ tag: "A" })).toEqual(E.right(T.mk.A))
       expect(cx.decode({ tag: "A", foo: "bar" })).toEqual(E.right(T.mk.A))
-      expect(cx.encode(T.mk.A)).not.toStrictEqual({ tag: "A", value: undefined })
+      expect(cx.encode(T.mk.A)).not.toStrictEqual({
+        tag: "A",
+        value: undefined,
+      })
       expect(cx.encode(T.mk.A)).toStrictEqual({ tag: "A" })
     })
   })

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -13,7 +13,7 @@ import {
   getExternallyTaggedCodec,
   getInternallyTaggedCodec,
   getAdjacentlyTaggedCodec,
-  nullary,
+  nullaryFromEmpty,
   nullaryFrom,
 } from "../../src/index"
 import * as t from "io-ts"
@@ -520,7 +520,7 @@ describe("index", () => {
     it("requires key to be present even if nullary", () => {
       type T = Sum.Member<"A">
       const T = Sum.create<T>()
-      const c = getExternallyTaggedCodec(T)({ A: nullary })
+      const c = getExternallyTaggedCodec(T)({ A: nullaryFromEmpty })
 
       expect(E.isLeft(c.decode({}))).toBe(true)
     })
@@ -547,7 +547,7 @@ describe("index", () => {
     } = T
 
     const c = getInternallyTaggedCodec("tag")(T)({
-      A: nullary,
+      A: nullaryFromEmpty,
       B: t.strict({ foo: NumberFromString }),
     })
 
@@ -605,7 +605,7 @@ describe("index", () => {
       expect(cn.decode({ tag: "A" })).not.toEqual(E.right(T.mk.A))
       expect(cn.encode(T.mk.A)).toEqual({ tag: "A" })
 
-      const cx = c({ A: nullary })
+      const cx = c({ A: nullaryFromEmpty })
       expect(cx.decode({ tag: "A" })).toEqual(E.right(T.mk.A))
       expect(cx.decode({ tag: "A", foo: "bar" })).toEqual(E.right(T.mk.A))
       expect(cx.encode(T.mk.A)).not.toStrictEqual({
@@ -687,7 +687,7 @@ describe("index", () => {
       expect(cn.decode({ tag: "A" })).not.toEqual(E.right(T.mk.A))
       expect(cn.encode(T.mk.A)).toEqual({ tag: "A", value: null })
 
-      const cu = c({ A: nullary })
+      const cu = c({ A: nullaryFromEmpty })
       expect(
         cu.decode({
           tag: "A",
@@ -704,7 +704,7 @@ describe("index", () => {
       const MaybeNum = Sum.create<Maybe<number>>()
       const c = getAdjacentlyTaggedCodec("_tag")("value")(MaybeNum)({
         Some: t.number,
-        None: nullary,
+        None: nullaryFromEmpty,
       })
 
       expect(c.decode(O.some(123))).toEqual(E.right(MaybeNum.mk.Some(123)))


### PR DESCRIPTION
Closes #5, #18, #19, #20, and #21. Borrows nomenclature from Serde [^1]. Enables decoding the following examples:

```ts
type Weather = Sum.Member<"Sun"> | Sum.Member<"Rain", { mm: number }>

// Externally tagged
{ Rain: { mm: 123 } }

// Internally tagged
{ tag: "Rain", mm: 123 }

// Adjacently tagged
{ tag: "Rain", value: { mm: 123 } }

// Untagged
{ mm: 123 }
```

- [x] I suspect there's a better way to handle `nullary`. :thinking: And maybe a rename to `nullaryCodec` for facade disambiguation.

[^1]: https://serde.rs/enum-representations.html