### PR TITLE
`getInternallyTaggedCodec`: preserve tag when decoding

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
+.direnv/
 node_modules/
 dist/
 coverage/
 docs/
-

--- a/flake.lock
+++ b/flake.lock
@@ -13,8 +13,9 @@
         "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
     "nixpkgs": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699459952,
+        "narHash": "sha256-y8FZLkjcNV5x/RCSgsIHc7FLa+6+/Yf8FTdkL9sHmAI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5426d70ea121c2094b63e272fb03d4fd1dcdeadb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    ,
+    }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.nodejs
+            pkgs.yarn
+          ];
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       in
       {
         devShells.default = pkgs.mkShell {
-          buildInputs = [
+          nativeBuildInputs = [
             pkgs.nodejs
             pkgs.yarn
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs =
     { self

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
 
   outputs =
     { self

--- a/src/index.ts
+++ b/src/index.ts
@@ -682,8 +682,7 @@ const getInternallyTaggedMemberCodec =
       (i, ctx) =>
         pipe(
           t.type({ [tagKey]: t.literal(tag) }).validate(i, ctx),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          E.chain(({ [tagKey]: _, ...rest }) => vc.validate(rest, ctx)),
+          E.chain(x => vc.validate(x, ctx)),
           E.map(x =>
             Sum.deserialize(sum)([tag, x] as unknown as Sum.Serialized<A>),
           ),

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -540,9 +540,7 @@ describe("index", () => {
   })
 
   describe("getInternallyTaggedCodec", () => {
-    type T =
-      | Sum.Member<"A">
-      | Sum.Member<"B", { readonly tag: "B"; readonly foo: number }>
+    type T = Sum.Member<"A"> | Sum.Member<"B", { readonly foo: number }>
     const T = Sum.create<T>()
     const {
       mk: { A, B },
@@ -550,12 +548,12 @@ describe("index", () => {
 
     const c = getInternallyTaggedCodec("tag")(T)({
       A: nullaryFromEmpty,
-      B: t.strict({ tag: t.literal("B"), foo: NumberFromString }),
+      B: t.strict({ foo: NumberFromString }),
     })
 
     it("type guards", () => {
       expect(c.is(A)).toBe(true)
-      expect(c.is(B({ tag: "B", foo: 123 }))).toBe(true)
+      expect(c.is(B({ foo: 123 }))).toBe(true)
 
       expect(c.is("A")).toBe(false)
       expect(c.is("B")).toBe(false)
@@ -568,10 +566,7 @@ describe("index", () => {
 
     it("encodes", () => {
       expect(c.encode(A)).toEqual({ tag: "A" })
-      expect(c.encode(B({ tag: "B", foo: 123 }))).toEqual({
-        tag: "B",
-        foo: "123",
-      })
+      expect(c.encode(B({ foo: 123 }))).toEqual({ tag: "B", foo: "123" })
     })
 
     it("does not decode bad inputs", () => {
@@ -581,7 +576,7 @@ describe("index", () => {
       expect(f("A")).toBe(true)
       expect(f("B")).toBe(true)
       expect(f(A)).toBe(true)
-      expect(f(B({ tag: "B", foo: 123 }))).toBe(true)
+      expect(f(B({ foo: 123 }))).toBe(true)
       expect(f({})).toBe(true)
       expect(f(false)).toBe(true)
       expect(f("123")).toBe(true)
@@ -594,10 +589,24 @@ describe("index", () => {
       fc.assert(
         fc.property(fc.integer({ min: 0 }), n =>
           expect(c.decode({ tag: "B", foo: String(n) })).toEqual(
-            E.right(B({ tag: "B", foo: n })),
+            E.right(B({ foo: n })),
           ),
         ),
       )
+    })
+
+    it("preserves tag after decode", () => {
+      type T = Sum.Member<"B", { readonly tag: "B" }>
+      const T = Sum.create<T>()
+      const {
+        mk: { B },
+      } = T
+
+      const c = getInternallyTaggedCodec("tag")(T)({
+        B: t.strict({ tag: t.literal("B") }),
+      })
+
+      expect(c.decode({ tag: "B" })).toEqual(E.right(B({ tag: "B" })))
     })
 
     // This is partially for documentative purposes.


### PR DESCRIPTION
Fixes https://github.com/unsplash/sum-types-io-ts/issues/25.